### PR TITLE
fix: to select the correct number of repo stars

### DIFF
--- a/source/ContentScript/index.ts
+++ b/source/ContentScript/index.ts
@@ -220,9 +220,7 @@ function checkForReleases() {
 }
 
 function getStars() {
-	const starButton = document.querySelector(
-		'button[aria-label="Star this repository"]'
-	);
+	const starButton = document.querySelector(".js-social-count");
 
 	const buttonParent = starButton?.parentElement;
 


### PR DESCRIPTION
fix: selector now selects from `.js-social-count`  to get the number of repo stars.