### PR TITLE
fix: stars count on newer versions of GitHub UI

### DIFF
--- a/source/ContentScript/index.ts
+++ b/source/ContentScript/index.ts
@@ -237,8 +237,13 @@ function getStars() {
 
   const buttonParent = starButton?.parentElement;
 
-  const socialCountElement = buttonParent?.querySelector(".social-count");
+  let socialCountElement = buttonParent?.querySelector(".social-count");
 
+  if (!socialCountElement) {
+    socialCountElement =
+        document.querySelector('#repo-stars-counter-unstar') ||
+        document.querySelector('#repo-stars-counter-star');
+  }
   if (socialCountElement) {
     return humanFormat.parse(socialCountElement.innerHTML) || 0;
   }


### PR DESCRIPTION
When running the extension on both Chrome and Firefox against [PlopJS, a repo I maintain with 5.3k stars](https://github.com/plopjs/plop), I noticed that it was indicating a fail state for the star counter. 

After some testing, I noticed that the last `querySelector`  failed to retrieve the star count. This PR fixes this by adding fallbacks in case the original value isn't retrieved.

Apologies if linting is a bit off - I kept running into ESLint warnings even after `npm i` so I couldn't verify against the linting ruleset